### PR TITLE
feat: historical borrow event catchup

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -179,6 +179,17 @@ def update_borrower_health_factor(
     borrowers[borrower].update({"health_factor": health_factor, "last_hf_update": block_number})
 
 
+def _get_unique_borrowers_from_logs(
+    start_block: int,
+    stop_block: int,
+) -> dict:
+    logs = POOL.Borrow.range(start_or_stop=start_block, stop=stop_block)
+    borrowers = {log.onBehalfOf: log.block_number for log in logs}
+
+    click.echo(f"Found {len(borrowers)} unique borrowers from historical events")
+    return borrowers
+
+
 @bot.on_worker_startup()
 def worker_startup(state: TaskiqState):
     state.borrowers = _load_borrowers_db()

--- a/bot.py
+++ b/bot.py
@@ -211,6 +211,31 @@ def _get_borrowers_health_factors(borrowers: dict) -> list:
     return results_with_borrowers
 
 
+def _update_borrowers_from_history(results: list) -> None:
+    borrowers = _load_borrowers_db()
+    positions = _load_positions_db()
+
+    borrowers_to_check = []
+    for borrower, data in results:
+        if borrower in borrowers:
+            borrowers[borrower].update(data)
+        else:
+            borrowers[borrower] = data
+            positions[borrower] = {
+                "debt_assets": "",
+                "collateral_assets": "",
+                "last_positions_update": 0,
+            }
+            borrowers_to_check.append(borrower)
+
+    if results:
+        _save_borrowers_db(borrowers)
+        _save_positions_db(positions)
+        click.echo(
+            click.echo(f"Updated DB: {len(results)} total, {len(borrowers_to_check)} to check")
+        )
+
+
 @bot.on_worker_startup()
 def worker_startup(state: TaskiqState):
     state.borrowers = _load_borrowers_db()


### PR DESCRIPTION
Add functionality to process historical borrower events on startup:
- Retrieve unique borrowers from past events
- Fetch borrower health factors via multicall
- Sync borrower and position databases with historical data